### PR TITLE
Remove use of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,10 @@
+from setuptools import setup, find_namespace_packages
 from xstatic.pkg import jquery as xs
 
 # The README.txt file should be written in reST so that PyPI can use
-# it to generate your project's PyPI page. 
+# it to generate your project's PyPI page.
 with open('README.txt') as f:
     long_description = f.read()
-
-from setuptools import setup, find_packages
 
 setup(
     name=xs.PACKAGE_NAME,
@@ -19,10 +18,8 @@ setup(
     license=xs.LICENSE,
     url=xs.HOMEPAGE,
     platforms=xs.PLATFORMS,
-    packages=find_packages(),
-    namespace_packages=['xstatic', 'xstatic.pkg', ],
+    packages=find_namespace_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=[],  # nothing! :)
-                          # if you like, you MAY use the 'XStatic' package.
+    install_requires=[],
 )

--- a/xstatic/__init__.py
+++ b/xstatic/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/__init__.py
+++ b/xstatic/pkg/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/xstatic/pkg/jquery/__init__.py
+++ b/xstatic/pkg/jquery/__init__.py
@@ -13,7 +13,7 @@ NAME = __name__.split('.')[-1] # package name (e.g. 'foo' or 'foo_bar')
 
 VERSION = '3.7.1' # version of the packaged files, please use the upstream
                   # version number
-BUILD = '0' # our package build number, so we can release new builds
+BUILD = '1'  # our package build number, so we can release new builds
              # with fixes for xstatic stuff.
 PACKAGE_VERSION = VERSION + '.' + BUILD # version used for PyPi
 


### PR DESCRIPTION
`pkg_resources` has been removed from setuptools 82.0.0. While we are hoping to get it restored in some way (see [here](https://github.com/pypa/setuptools/issues/5174) and [here](https://github.com/pypa/setuptools/issues/863)), `pkg_resources`-style namespaces have long been deprecated in favour of [native namespaces](https://peps.python.org/pep-0420/).

Migrate this package to native namespaces and bump the package version. This mirrors what has been done for the many other xstatic packages [maintained by the OpenStack community](https://review.opendev.org/q/topic:%22remove-pkg_resources%22+project:%22%5Eopenstack/xstatic-.*%22+is:merged)
